### PR TITLE
sd-skip-empty-shopify-email-responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.3.3
+
+* Skip empty email responses from Shopify

--- a/lib/external_service_new/shopify_downloader.rb
+++ b/lib/external_service_new/shopify_downloader.rb
@@ -46,7 +46,11 @@ module ExternalServiceNew
         response = dispatcher.dispatch(:get, "/admin/customers/search.json?page=#{page}&limit=250&fields=email")
         break if response["customers"].empty?
 
-        response["customers"].each {|customer| yield customer["email"]}
+        response["customers"].each do |customer|
+          next unless customer && customer["email"]
+
+          yield customer["email"]
+        end
         page += 1
       end
 

--- a/lib/wafflehouse/version.rb
+++ b/lib/wafflehouse/version.rb
@@ -1,3 +1,3 @@
 module Wafflehouse
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
Après vérification, la réponse de shopify est soit vide, soit contenant un email. Il est donc inutile de logger quoi que ce soit. 